### PR TITLE
Adicionar configuração de CI para build e testes em C++

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: C++ CI
+
+# Executar o fluxo de trabalho em pushes e pull requests para a branch main
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    build_and_test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Set up C++ environment
+              uses: actions/setup-cpp@v1
+              with:
+                  compiler: gcc
+
+            - name: Install dependencies
+              run: sudo apt-get install -y build-essential cmake
+
+            - name: Build project
+              run: |
+                  mkdir -p build
+                  cd build
+                  cmake ..
+                  make
+
+            - name: Run tests
+              run: |
+                  cd build
+                  ./bin/simulador ../data/first_test 
+            - name: Upload artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: build-artifact
+                  path: bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: build-artifact
-                  path: bin/
+                  path: build/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Set up C++ environment
-              uses: actions/setup-cpp@v1
+              uses: cpp-actions/setup-cpp@v1
               with:
                   compiler: gcc
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building and testing the C++ project on pushes and pull requests to the `main` branch. The workflow ensures code quality by compiling the project and running tests in a CI environment.

Continuous Integration setup:

* Added `.github/workflows/ci.yml` to define a CI pipeline that triggers on pushes and pull requests to the `main` branch.
* Configured the workflow to check out the repository, set up a C++ environment with GCC, install build dependencies, build the project using CMake and Make, run tests with the `simulador` binary, and upload build artifacts for later use.