### PR TITLE
Refactor simulation logic to enhance encounter detection and reportin…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,29 @@
 name: C++ CI
 
 # Executar o fluxo de trabalho em pushes e pull requests para a branch main
+
 on:
-    push:
-        branches:
-            - main
-    pull_request:
-        branches:
-            - main
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+
+# Garantir que apenas uma execução do fluxo de trabalho por branch esteja em andamento
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
     build_and_test:
         runs-on: ubuntu-24.04
+
+        # Adicionar permissão de leitura para o conteúdo do repositório
+        permissions:
+          contents: read
+        env:
+          BUILD_TYPE: Release
+          LAB_ANIM_DELAY_MS: 0
 
         steps:
             - name: Checkout repository
@@ -21,6 +33,9 @@ jobs:
               uses: aminya/setup-cpp@v1.7.1
               with:
                  compiler: gcc
+                 cmake: true
+                 ninja: true
+                 ccache: true
 
             - name: Cache build directory
               id: cache-build
@@ -38,13 +53,15 @@ jobs:
                 cmake ..
                 cmake --build . --parallel
 
-            - name: Run tests
-              run: |
-                  cd build
-                  ./bin/simulador ../data/first_test 
-            - name: Upload artifact
-              # v4.3.1 (latest as of June 2024)
-              uses: actions/upload-artifact@v4
+            - name: Smoke tests (JSON scenarios)
+              run: python3 scripts/ci_validate.py ./build/bin/simulador
+            
+            - name: Publish GitHub Release (attach binary)
+              if: startsWith(github.ref, 'refs/tags/v')
+              uses: softprops/action-gh-release@v2
               with:
-                  name: build-artifact
-                  path: build/bin/
+                files: build/bin/simulador
+                draft: false
+                prerelease: false
+                fail_on_unmatched_files: true
+              

--- a/include/labirinto/Simulador.h
+++ b/include/labirinto/Simulador.h
@@ -25,6 +25,7 @@ public:
     struct ResultadoSimulacao{
         bool prisioneiroSobreviveu;
         int diasSobrevividos;
+    double tempoReal; // tempo contínuo da simulação
         std::vector<int> caminhoP;
         std::vector<int> caminhoM;
         std::string motivoFim;
@@ -32,9 +33,16 @@ public:
         int posFinalP;
         int posFinalM;
         bool minotauroVivo;
+    // Novo: Linha do tempo e encontro
+    std::vector<Logger::EventoMovimento> eventos;
+    double tempoEncontro = -1.0;
+    std::string tipoEncontro; // "sala" ou "aresta"
     };
 
     ResultadoSimulacao run(unsigned int seed, int chanceBatalha);
+
+    // Informações para cabeçalho humano
+    Logger::SimulacaoInfo getSimulacaoInfo() const;
 
 private:
     bool cheiroDePrisioneiro(int posMinotauro, int posPrisioneiro, int percepcao, Minotauro& m);
@@ -42,6 +50,10 @@ private:
     void turnoPrisioneiro(Prisioneiro& p);
     int turnoMinotauro(Minotauro& m, int posPrisioneiro, std::mt19937& gerador,  bool cheiroDePrisioneiro);
     void verificaEstados(Prisioneiro& p, Minotauro& m, bool& fimDeJogo, bool& minotauroVivo, std::string& motivoFim, unsigned int seed, int chanceBatalha, std::mt19937& gerador);
+
+    // Detecção/agendamento de encontro em trânsito na mesma aresta (sentidos opostos)
+    bool detectarEncontroEmAresta(double& tEncontroOut);
+    void agendarEncontroEmArestaSeNecessario();
 
 
     Grafo labirinto;
@@ -63,4 +75,18 @@ private:
     double tempoGlobal;
     double prxMovP;
     double prxMovM;
+
+    // Posições efetivas para checagem durante deslocamentos
+    int ultimaPosP; // última sala do prisioneiro antes do deslocamento atual
+    int ultimaPosM; // última sala do minotauro antes do deslocamento atual
+
+    // Rastreio do deslocamento atual (para encontros em aresta)
+    int destAtualP = -1;
+    int destAtualM = -1;
+    double inicioMovP = 0.0;
+    double inicioMovM = 0.0;
+
+    // Evento de encontro em trânsito
+    bool encontroEdgePendente = false;
+    double tempoEncontroEdge = -1.0;
 };

--- a/scripts/ci_validate.py
+++ b/scripts/ci_validate.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+
+SCENARIOS = [
+    'data/fuga',
+    'data/escape',
+    'data/perseguicao_imediata',
+    'data/first_test',
+    'data/beco_sem_saida',
+    'data/morte_fome',
+    'data/teste_distante',
+]
+
+BIN = os.path.join('build', 'bin', 'simulador')
+
+
+def run_scenario(path: str):
+    cmd = [BIN, path, '--json-only']
+    res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if res.returncode != 0:
+        print(f"Scenario {path} failed to run. RC={res.returncode}. stderr=\n{res.stderr}")
+        return None
+    try:
+        data = json.loads(res.stdout)
+        return data
+    except json.JSONDecodeError:
+        print(f"Scenario {path} produced non-JSON output:\n{res.stdout}\n--- stderr ---\n{res.stderr}")
+        return None
+
+
+def main():
+    if not os.path.exists(BIN):
+        print(f"Binary not found: {BIN}")
+        sys.exit(1)
+
+    failures = 0
+    for s in SCENARIOS:
+        if not os.path.exists(s):
+            print(f"Skipping missing scenario: {s}")
+            continue
+        data = run_scenario(s)
+        if data is None:
+            failures += 1
+            continue
+        # Basic shape checks
+        for k in ['sobreviveu', 'tempo', 'tempoReal', 'kits', 'posP', 'posM', 'minotauroVivo', 'encontro']:
+            if k not in data:
+                print(f"Scenario {s}: missing key '{k}' in JSON")
+                failures += 1
+        # Consistency: tempo vs tempoReal rounding down
+        if 'tempo' in data and 'tempoReal' in data:
+            if data['tempo'] != int(data['tempoReal']):
+                print(f"Scenario {s}: tempo != floor(tempoReal) ({data['tempo']} vs {data['tempoReal']})")
+                # Not fatal, just warn
+        # encontro object shape
+        enc = data.get('encontro', {})
+        for k in ['ok', 'tipo', 't']:
+            if k not in enc:
+                print(f"Scenario {s}: encontro missing '{k}'")
+                failures += 1
+
+    if failures:
+        print(f"CI validation: {failures} issues found")
+        sys.exit(1)
+    print("CI validation: OK")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,14 +12,27 @@ struct ConfiguracaoSimulacao {
 };
 
 int main(int argc, char* argv[]) {
-    Logger::info(0.0, "[TESTE] Logger está funcionando!", Logger::LogSource::OUTRO);
-
     if (argc < 2) {
-        std::cerr << "Uso: " << argv[0] << " <arquivo>" << std::endl;
+        std::cerr << "Uso: " << argv[0] << " <arquivo> [--json-only | --human]" << std::endl;
         return 1;
     }
     // Nome do arquivo passado como argumento
     std::string nomeArquivo = argv[1];
+    bool jsonOnly = false;
+    bool humanReport = true; // padrão
+    if (argc >= 3) {
+        std::string flag = argv[2];
+        if (flag == "--json-only") { jsonOnly = true; humanReport = false; }
+        else if (flag == "--human") { humanReport = true; jsonOnly = false; }
+    }
+
+    // Definir nível de log conforme modo selecionado antes de qualquer log
+    if (jsonOnly) {
+        Logger::setLevel(LogLevel::ERROR); // suprime INFO/WARN/DEBUG em json-only
+    } else {
+        Logger::setLevel(LogLevel::DEBUG);
+        Logger::info(0.0, "[TESTE] Logger está funcionando!", Logger::LogSource::OUTRO);
+    }
 
     // Abre o arquivo para leitura
     std::ifstream file(nomeArquivo);
@@ -32,27 +45,82 @@ int main(int argc, char* argv[]) {
 
     try {
         Simulador simulation;
-        if (!simulation.carregarArquivo(nomeArquivo)) {
+    if (!simulation.carregarArquivo(nomeArquivo)) {
             return 1; // Encerra se o arquivo não puder ser carregado
+        }
+        // Imprimir cabeçalho estilizado apenas em modo humano
+        if (humanReport && !jsonOnly) {
+            Logger::imprimirInicioSimulacao(simulation.getSimulacaoInfo());
         }
 
         Simulador::ResultadoSimulacao resultado = simulation.run(1, 1); // Seed 1, Chance 1%
 
-        // MELHORIA: Relatório final detalhado
-        std::cout << "\n\n";
-        std::cout << "======================================================\n";
-        std::cout << "             RELATÓRIO FINAL DA SIMULAÇÃO             \n";
-        std::cout << "======================================================\n";
-        std::cout << "  Resultado: " << (resultado.prisioneiroSobreviveu ? "Sim" : "Não");
-        std::cout << "  Motivo: " << resultado.motivoFim << "\n";
-        std::cout << "------------------------------------------------------\n";
-        std::cout << "  Tempo total de sobrevivência: " << resultado.diasSobrevividos << " unidades de tempo\n";
-        std::cout << "  Kits de comida restantes: " << resultado.kitsRestantes << "\n";
-        std::cout << "  Posição final do Prisioneiro: Sala " << resultado.posFinalP << "\n";
-        std::cout << "  Posição final do Minotauro: Sala " << resultado.posFinalM << "\n";
-        std::cout << "  Minotauro sobreviveu: " << (resultado.minotauroVivo ? "Sim" : "Não") << "\n";
-        std::cout << "------------------------------------------------------\n";
-        std::cout << "======================================================\n";
+    if (humanReport && !jsonOnly) {
+            // RELATÓRIO HUMANO COM DESTAQUE
+            std::cout << "\n\n";
+            std::cout << "======================================================\n";
+            std::cout << "             RELATÓRIO FINAL DA SIMULAÇÃO             \n";
+            std::cout << "======================================================\n";
+            std::cout << "  Resultado: " << (resultado.prisioneiroSobreviveu ? "Sim" : "Não")
+                      << "  Motivo: " << (resultado.motivoFim.empty() ? (resultado.prisioneiroSobreviveu ? "O prisioneiro escapou com sucesso!" : "") : resultado.motivoFim) << "\n";
+            std::cout << "------------------------------------------------------\n";
+            std::cout << "  Tempo total de sobrevivência: " << resultado.diasSobrevividos << " unidades de tempo\n";
+            std::cout << "  Kits de comida restantes: " << resultado.kitsRestantes << "\n";
+            std::cout << "  Minotauro sobreviveu: " << (resultado.minotauroVivo ? "Sim" : "Não") << "\n";
+            if (resultado.tempoEncontro >= 0) {
+                std::cout << "  Encontro: sim (tipo: " << resultado.tipoEncontro << ", t=" << std::fixed << std::setprecision(2) << resultado.tempoEncontro << ")\n";
+            } else {
+                std::cout << "  Encontro: não\n";
+            }
+            std::cout << "------------------------------------------------------\n";
+            // Caminhos
+            std::cout << "  Caminho do Prisioneiro: ";
+            for (size_t i = 0; i < resultado.caminhoP.size(); ++i) {
+                std::cout << resultado.caminhoP[i];
+                if (i + 1 < resultado.caminhoP.size()) std::cout << " -> ";
+            }
+            std::cout << "\n";
+            std::cout << "  Caminho do Minotauro: ";
+            for (size_t i = 0; i < resultado.caminhoM.size(); ++i) {
+                std::cout << resultado.caminhoM[i];
+                if (i + 1 < resultado.caminhoM.size()) std::cout << " -> ";
+            }
+            std::cout << "\n";
+            std::cout << "------------------------------------------------------\n";
+            // Linha do tempo com barras e destaque de encontro
+            if (!resultado.eventos.empty()) {
+                std::string local;
+                if (resultado.tempoEncontro >= 0) {
+                    if (resultado.tipoEncontro == "sala") {
+                        local = "Sala " + std::to_string(resultado.posFinalP);
+                    } else if (resultado.tipoEncontro == "aresta" && !resultado.eventos.empty()) {
+                        // usar último par de movimentos em conflito como contexto simples
+                        // nota: para precisão, o simulador poderia preencher explicitamente origem/destino do encontro
+                        int u = resultado.eventos.back().origem;
+                        int v = resultado.eventos.back().destino;
+                        local = "Corredor " + std::to_string(u) + "–" + std::to_string(v);
+                    }
+                }
+                Logger::printarLogsComProgresso(resultado.eventos, resultado.tempoEncontro, resultado.tipoEncontro, local);
+            }
+            std::cout << "======================================================\n";
+        }
+
+        // JSON resumido (somente se solicitado explicitamente ou padrão se jsonOnly)
+    if (jsonOnly) {
+        std::cout << "{\n" 
+                  << "  \"sobreviveu\": " << (resultado.prisioneiroSobreviveu ? "true" : "false") << ",\n"
+            << "  \"tempo\": " << resultado.diasSobrevividos << ",\n"
+            << "  \"tempoReal\": " << std::fixed << std::setprecision(6) << resultado.tempoReal << ",\n"
+                  << "  \"kits\": " << resultado.kitsRestantes << ",\n"
+                  << "  \"posP\": " << resultado.posFinalP << ",\n"
+                  << "  \"posM\": " << resultado.posFinalM << ",\n"
+                  << "  \"minotauroVivo\": " << (resultado.minotauroVivo ? "true" : "false") << ",\n"
+                  << "  \"encontro\": { \"ok\": " << (resultado.tempoEncontro >= 0 ? "true" : "false")
+                  << ", \"tipo\": \"" << (resultado.tempoEncontro >= 0 ? resultado.tipoEncontro : "") << "\", \"t\": "
+                  << (resultado.tempoEncontro >= 0 ? resultado.tempoEncontro : -1) << " }\n";
+            std::cout << "}\n";
+        }
     } catch (const std::exception& e) {
     Logger::error(0.0, "Uma exceção crítica ocorreu: {}", Logger::LogSource::OUTRO, e.what());
         return 1;


### PR DESCRIPTION
This pull request introduces significant improvements to the simulation workflow, focusing on enhanced encounter detection, more detailed simulation logging, and better CI validation. The changes add support for detecting and handling encounters between agents both in rooms and while traversing edges, extend the simulation result structure to capture more granular details, and overhaul the CI pipeline to validate scenarios using JSON outputs. Additionally, the logging system now provides animated, chronological progress and highlights decisive encounters.

**Simulation logic and encounter detection:**

* Added detection and scheduling of encounters between the prisoner and minotaur while both are traversing the same edge in opposite directions, not just when occupying the same room. The simulation now resolves battles and records encounter details for both cases. (`Simulador.h`, `Simulador.cpp`) [[1]](diffhunk://#diff-0b9d0b445795ec952e54611aa54568d7e48016f4b61f3094e6db1fbd3dfeeb66R28-R57) [[2]](diffhunk://#diff-0b9d0b445795ec952e54611aa54568d7e48016f4b61f3094e6db1fbd3dfeeb66R78-R91) [[3]](diffhunk://#diff-0987a290e4edea14c7036dcf60b460e5ba987a018df4891cee22158eae676298R84-R93) [[4]](diffhunk://#diff-0987a290e4edea14c7036dcf60b460e5ba987a018df4891cee22158eae676298L99-R159) [[5]](diffhunk://#diff-0987a290e4edea14c7036dcf60b460e5ba987a018df4891cee22158eae676298L139-R196) [[6]](diffhunk://#diff-0987a290e4edea14c7036dcf60b460e5ba987a018df4891cee22158eae676298R207)

**Simulation result and logging enhancements:**

* Extended the `ResultadoSimulacao` structure to include continuous simulation time, a timeline of movement events, and detailed encounter information (type, time, location). (`Simulador.h`, `Simulador.cpp`) [[1]](diffhunk://#diff-0b9d0b445795ec952e54611aa54568d7e48016f4b61f3094e6db1fbd3dfeeb66R28-R57) [[2]](diffhunk://#diff-0987a290e4edea14c7036dcf60b460e5ba987a018df4891cee22158eae676298R170)
* Improved the logging system to render animated progress bars for agent movements, show chronological events, and visually highlight decisive encounters with extended formatting. (`Logger.h`) [[1]](diffhunk://#diff-86cc62b86dc29f8828745a6a5d393a112c8b80b14c73649682776bc6c3f3215bR152-R157) [[2]](diffhunk://#diff-86cc62b86dc29f8828745a6a5d393a112c8b80b14c73649682776bc6c3f3215bL321-R421)

**Continuous Integration and release workflow:**

* Updated the GitHub Actions CI workflow to run on both pushes and tags, enable concurrency control, set environment variables, and add permissions for repository contents. The workflow now uses CMake, Ninja, and ccache for builds, runs smoke tests on multiple scenarios using a new Python script, and automatically publishes releases with attached binaries for tagged builds. (`.github/workflows/ci.yml`, `ci_validate.py`) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR4-R27) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR36-R38) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL41-R67) [[4]](diffhunk://#diff-09e1ecfcde00cd1bb5cff68327cb4ae5028a1c01f4acc38d251a35b3c94abaeeR1-R72)

**Codebase and initialization improvements:**

* Refactored simulation initialization and state reset logic to ensure all fields are correctly set at the start of each run, and moved responsibility for printing headers to the caller for better output control. (`Simulador.cpp`) [[1]](diffhunk://#diff-0987a290e4edea14c7036dcf60b460e5ba987a018df4891cee22158eae676298R14-R17) [[2]](diffhunk://#diff-0987a290e4edea14c7036dcf60b460e5ba987a018df4891cee22158eae676298L64-R65) [[3]](diffhunk://#diff-0987a290e4edea14c7036dcf60b460e5ba987a018df4891cee22158eae676298R84-R93)

**Utility and performance:**

* Added new headers and utility functions to support set operations, algorithmic checks, and environment-based animation delays in logging. (`Logger.h`) [[1]](diffhunk://#diff-86cc62b86dc29f8828745a6a5d393a112c8b80b14c73649682776bc6c3f3215bR21-R23) [[2]](diffhunk://#diff-86cc62b86dc29f8828745a6a5d393a112c8b80b14c73649682776bc6c3f3215bL321-R421)